### PR TITLE
fix: downgrade openssl for test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "postinstall": "husky install",
     "prettier": "prettier --config ./.prettierrc.yaml --write \"**/*.{js,json,md,sol,ts}\"",
     "prettier:check": "prettier --check --config ./.prettierrc.yaml \"**/*.{js,json,md,sol,ts}\"",
-    "test": "hardhat test",
+    "test": "NODE_OPTIONS=--openssl-legacy-provider hardhat test",
     "typechain": "cross-env TS_NODE_TRANSPILE_ONLY=true hardhat typechain"
   },
   "dependencies": {


### PR DESCRIPTION
FYI @amosperion.

Couldn't run the tests before as I was getting the following error:

`Error: error:0308010C:digital envelope routines::unsupported` 

This fixes it. 