### PR TITLE
add distribution script for rewards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 INFURA_API_KEY=zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
 MNEMONIC=here is where your twelve words mnemonic should be put my friend
+SPERC=
+SLPPERC=

--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
   ],
   "private": true,
   "scripts": {
+    "approveAndDistribute": "npm run approve && npm run distribute",
+    "approve": "npx hardhat run scripts/rewards/Approve.ts --network mainnet",
+    "distribute": "npx hardhat run scripts/rewards/DistributeRewards.ts --network mainnet",
     "clean": "cross-env TS_NODE_TRANSPILE_ONLY=true hardhat clean",
     "commit": "git-cz",
     "compile": "cross-env COMPILE_ONLY=true TS_NODE_TRANSPILE_ONLY=true hardhat compile",

--- a/scripts/rewards/Approve.ts
+++ b/scripts/rewards/Approve.ts
@@ -1,0 +1,25 @@
+// TODO fill vars
+import { ethers } from 'hardhat'
+const PERC = "0x60be1e1fe41c1370adaf5d8e66f07cf1c2df2268";
+const sPERC = "";
+const sLPPERC = "";
+const MAX_INT = ethers.BigNumber.MAX_VALUE;
+
+async function main() {
+  const signers = await ethers.getSigners();
+  const percToken = await ethers.getContractFactory('ERC20');
+  percToken.attach(PERC);
+  const allowanceSPERC = await percToken.allowance(signers[0], sPERC);
+  if(allowanceSPERC !== MAX_INT) {
+    await percToken.approve(sPERC, MAX_INT);
+  }
+  const allowanceLP = await percToken.allowance(signers[0], sLPPERC);
+  if(allowanceLP !== MAX_INT) {
+    await percToken.approve(sLPPERC, MAX_INT);
+  }
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/scripts/rewards/DistributeRewards.ts
+++ b/scripts/rewards/DistributeRewards.ts
@@ -1,0 +1,20 @@
+import { ethers } from 'hardhat'
+import { parseEther } from "ethers/lib/utils";
+const sPERC = process.ENV.SPERC;
+const sLPPERC = process.ENV.SLPPERC;
+const dailySPERCAllocation = parseEther("1357.4");
+const dailyLPAllocation = parseEther("5429.6");
+
+// Run the Approve script first
+async function main() {
+  const stakingContractBasePool = await ethers.getContractFactory('BasePool');
+  stakingContractBasePool.attach(sPERC);
+  await stakingContractBasePool.distributeRewards(dailySPERCAllocation);
+  stakingContractBasePool.attach(sLPPERC);
+  await stakingContractBasePool.distributeRewards(dailyLPAllocation);
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
This PR:

1. Adds a distribution script for rewards (that can be sent from a hot wallet)
2. Adds an approval script which must be run once so that the hot wallet can distribute funds via the `BasePool` contract

If we end up using heroku to run this script, we will need to:

1. Top up the wallet with sufficient funds (in both PERC and ETH)
2. Store the private key in heroku's environment config vars (with a strong password and 2FA)
3. Run the approval script once with `$ npm run approve`
4. Setup the heroku scheduler to run `$ npm run distribute` each day at a particular UTC time
5. Periodically topup the hot wallet with funds 

Since the contracts have not yet been deployed, #32 must still be done. 